### PR TITLE
Making the library work with the Arduino IDE.

### DIFF
--- a/src/dmx.cpp
+++ b/src/dmx.cpp
@@ -1,8 +1,4 @@
 #include <dmx.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/queue.h"
-#include "driver/uart.h"
 
 #define DMX_SERIAL_INPUT_PIN    16          // pin for dmx rx
 #define DMX_SERIAL_OUTPUT_PIN   17          // pin for dmx tx

--- a/src/dmx.h
+++ b/src/dmx.h
@@ -1,3 +1,11 @@
+#include <stdint.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "driver/uart.h"
+
 #ifndef DMX_h
 #define DMX_h
 


### PR DESCRIPTION
These two pull requests include two libraries that are required to compile the code correctly (stdint.h and string.h) and also moves includes from the source file to the header file because their types are used in the header file. This eliminates the need for a correct ordering of the include statements. Before the change Arduino IDE wouldn't compile even the example and now it works out of the box. I believe that the changes also shouldn't affect any other build environments since the includes were only moved to the header file and still get included.